### PR TITLE
Build using exoeconomy/blockcore asset rather than FluidChains/FullNode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
     env:
       PROJECT_NAME: 'OpenExo.Node'
-      DAEMON: '1.0.22'
+      DAEMON: '1.0.21'
       ARCH: 'x64'
       ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
@@ -64,7 +64,7 @@ jobs:
       run: |
         echo ${env:PATH}
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        $url = "https://github.com/Fluidchains/FullNode/releases/download/${{ env.DAEMON }}/EXOS-${{ env.DAEMON }}-${{ matrix.platform }}-${{ env.ARCH }}${{ matrix.extension }}"
+        $url = "https://github.com/exoeconomy/blockcore/releases/download/${{ env.DAEMON }}/OpenExo.Node-${{ env.DAEMON }}-${{ matrix.platform }}-${{ env.ARCH }}${{ matrix.extension }}"
         $output = Join-Path -Path "./" -ChildPath "daemon${{ matrix.extension }}"
         Write-Output "Url: $url"
         Write-Output "Path: $output"


### PR DESCRIPTION
The full node is automatically built by GitHub Actions in https://github.com/exoeconomy/blockcore and uploaded as a release: https://github.com/exoeconomy/blockcore/releases

The release uploaded in https://github.com/FluidChains/FullNode/releases is based on the source in @exoeconomy/blockcore and is a manual upload of the automatically built one. The last released version upstream is 1.0.21. This should fix automatic build & release of assets using the CI pipeline.